### PR TITLE
IS-84 Add Image Carousel to Review Component

### DIFF
--- a/frontend/isoko/src/components/Review.tsx
+++ b/frontend/isoko/src/components/Review.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Rating } from 'react-simple-star-rating';
+import ImageCarousel from './business/ImageCarousel';
 
 const ReviewContainer = styled.div`
    display: flex;
@@ -9,14 +10,6 @@ const ReviewContainer = styled.div`
    padding: 0.5em;
    margin: 0em 0em 1em 1em;
    border-left: 2px solid #999999;
-`;
-
-const UserPhoto = styled.img`
-   height: 30px;
-   width: 30px;
-   object-fit: cover;
-   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-   border-radius: 50%;
 `;
 
 const ReviewPhoto = styled.img`
@@ -32,6 +25,14 @@ const ReviewPhotoContainer = styled.div`
    justify-content: space-evenly;
    margin-top: 1em;
    align-items: center;
+`;
+
+const UserPhoto = styled.img`
+   height: 30px;
+   width: 30px;
+   object-fit: cover;
+   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+   border-radius: 50%;
 `;
 
 const UserContainer = styled.div`
@@ -52,6 +53,11 @@ const StarContainer = styled.div`
    margin: -0.5em 0em 0em 0em;
 `;
 
+const StyledCarousel = styled(ImageCarousel)`
+   width: 100%;
+   margin-top: 5px;
+`;
+
 interface ReviewProps extends React.HTMLProps<HTMLDivElement> {
    reviewerName: string;
    reviewerImageUrl: string;
@@ -62,6 +68,10 @@ interface ReviewProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 const Review: React.FC = (props: ReviewProps) => {
+   let images = props.imageUrls;
+   if (images == null) {
+      images = [];
+   }
    return (
       <ReviewContainer className={props.className}>
          <UserContainer>
@@ -84,13 +94,15 @@ const Review: React.FC = (props: ReviewProps) => {
          ) : (
             <br></br>
          )}
-         {props.imageUrls ? (
+         {images.length >= 3 ? (
+            <StyledCarousel images={images}></StyledCarousel>
+         ) : (
             <ReviewPhotoContainer>
-               {props.imageUrls.map((photo, index) => (
+               {images.map((photo, index) => (
                   <ReviewPhoto key={index} src={photo}></ReviewPhoto>
                ))}
             </ReviewPhotoContainer>
-         ) : null}
+         )}
       </ReviewContainer>
    );
 };

--- a/frontend/isoko/src/components/Review.tsx
+++ b/frontend/isoko/src/components/Review.tsx
@@ -17,12 +17,13 @@ const ReviewPhoto = styled.img`
    max-height: 40%;
    object-fit: contain;
    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+   margin: 0px 7px 0px 0px;
 `;
 
 const ReviewPhotoContainer = styled.div`
    display: flex;
    flex-direction: row;
-   justify-content: space-evenly;
+   justify-content: start;
    margin-top: 1em;
    align-items: center;
 `;

--- a/frontend/isoko/src/components/Review.tsx
+++ b/frontend/isoko/src/components/Review.tsx
@@ -18,7 +18,7 @@ interface ReviewPhotoProps {
 
 const ReviewPhoto = styled.img<ReviewPhotoProps>`
    max-height: 200px;
-   max-width: ${(props) => `${props.maxWidth}%`}
+   max-width: ${(props) => `${props.maxWidth}%`};
    object-fit: contain;
    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
    margin: 0px 7px 0px 0px;
@@ -105,7 +105,7 @@ const Review: React.FC = (props: ReviewProps) => {
             <ReviewPhotoContainer>
                {images.map((photo, index) => (
                   <ReviewPhoto
-                     maxWidth={100 / images.length}
+                     maxWidth={images.length === 2 ? 48 : 75}
                      key={index}
                      src={photo}
                   ></ReviewPhoto>

--- a/frontend/isoko/src/components/Review.tsx
+++ b/frontend/isoko/src/components/Review.tsx
@@ -12,9 +12,13 @@ const ReviewContainer = styled.div`
    border-left: 2px solid #999999;
 `;
 
-const ReviewPhoto = styled.img`
-   max-width: 32.5%;
-   max-height: 40%;
+interface ReviewPhotoProps {
+   maxWidth?: number;
+}
+
+const ReviewPhoto = styled.img<ReviewPhotoProps>`
+   max-height: 200px;
+   max-width: ${(props) => `${props.maxWidth}%`}
    object-fit: contain;
    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
    margin: 0px 7px 0px 0px;
@@ -56,7 +60,7 @@ const StarContainer = styled.div`
 
 const StyledCarousel = styled(ImageCarousel)`
    width: 100%;
-   margin-top: 5px;
+   margin-top: 1em;
 `;
 
 interface ReviewProps extends React.HTMLProps<HTMLDivElement> {
@@ -96,11 +100,15 @@ const Review: React.FC = (props: ReviewProps) => {
             <br></br>
          )}
          {images.length >= 3 ? (
-            <StyledCarousel images={images}></StyledCarousel>
+            <StyledCarousel maxHeight={200} images={images}></StyledCarousel>
          ) : (
             <ReviewPhotoContainer>
                {images.map((photo, index) => (
-                  <ReviewPhoto key={index} src={photo}></ReviewPhoto>
+                  <ReviewPhoto
+                     maxWidth={100 / images.length}
+                     key={index}
+                     src={photo}
+                  ></ReviewPhoto>
                ))}
             </ReviewPhotoContainer>
          )}

--- a/frontend/isoko/src/components/business/BusinessSidebar.tsx
+++ b/frontend/isoko/src/components/business/BusinessSidebar.tsx
@@ -167,7 +167,7 @@ const ClaimBusinessSection = () => {
                navigate('/claim');
             }}
          >
-            Claim Bussiness
+            Claim Business
          </ClaimBusinessButton>
       </div>
    );

--- a/frontend/isoko/src/components/business/ImageCarousel.tsx
+++ b/frontend/isoko/src/components/business/ImageCarousel.tsx
@@ -19,6 +19,7 @@ const Photo = styled.img`
    border-radius: 5px;
    object-fit: cover;
    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+   max-height: ${(props) => (props.maxHeight ? `${props.maxHeight}px` : null)};
 `;
 
 const RightArrow = styled(FontAwesomeIcon)`
@@ -37,6 +38,7 @@ const LeftArrow = styled(FontAwesomeIcon)`
 
 interface CarouselProps extends React.HTMLProps<HTMLDivElement> {
    images: string[];
+   maxHeight: number;
 }
 
 const CustomRightArrow = ({ onClick }: ArrowProps) => (
@@ -71,7 +73,7 @@ const ImageCarousel: React.FC<CarouselProps> = (props) => {
             infinite={true}
          >
             {images.map((img, idx) => (
-               <Photo src={img} key={idx} />
+               <Photo maxHeight={props.maxHeight} src={img} key={idx} />
             ))}
          </Carousel>
       </CarouselContainer>


### PR DESCRIPTION
A review with 3 or more images now has an image carousel. 
- A review with 2 or fewer images will appear the same as it did before.
- Let me know if you want me to change it to 4 or more images for the image carousel to appear.

This PR improves the review component by allowing it to have more than 3 images which was a previous restriction and adds some consistency to how we handle photos.
<img width="415" alt="Screen Shot 2022-02-19 at 5 10 43 PM" src="https://user-images.githubusercontent.com/46057294/154824515-e6d8f982-65e4-4af6-a466-75575442b4d7.png">
