### PR TITLE
Change search results endpoint to a POST endpoint

### DIFF
--- a/backend/isoko-backend/__tests__/unit/handlers/business/post-search-results.test.js
+++ b/backend/isoko-backend/__tests__/unit/handlers/business/post-search-results.test.js
@@ -1,12 +1,12 @@
 const {
-   getSearchResultsHandler,
-} = require('../../../../src/handlers/business/get-search-results.js');
+   postSearchResultsHandler,
+} = require('../../../../src/handlers/business/post-search-results.js');
 const dynamodb = require('aws-sdk/clients/dynamodb');
 const { BUSINESS_TABLE } = require('../../../../src/constants');
 
 jest.mock('aws-sdk/clients/dynamodb');
 
-describe('GetSearchResultsHandler tests', () => {
+describe('PostSearchResultsHandler tests', () => {
    let querySpy;
 
    beforeAll(() => {
@@ -32,7 +32,7 @@ describe('GetSearchResultsHandler tests', () => {
 
          // assert
          await expect(async () => {
-            await getSearchResultsHandler(event);
+            await postSearchResultsHandler(event);
          }).rejects.toThrowError();
       });
 
@@ -49,7 +49,7 @@ describe('GetSearchResultsHandler tests', () => {
 
          // assert
          await expect(async () => {
-            await getSearchResultsHandler(event);
+            await postSearchResultsHandler(event);
          }).rejects.toThrowError('CA');
       });
 
@@ -66,7 +66,7 @@ describe('GetSearchResultsHandler tests', () => {
 
          // assert
          await expect(async () => {
-            await getSearchResultsHandler(event);
+            await postSearchResultsHandler(event);
          }).rejects.toThrowError('CA/Sunnyvale/SantaClara');
       });
    });
@@ -90,7 +90,7 @@ describe('GetSearchResultsHandler tests', () => {
          };
 
          // act
-         const result = await getSearchResultsHandler(event);
+         const result = await postSearchResultsHandler(event);
 
          // assert
          expect(result).toEqual(expectedItem);
@@ -172,7 +172,7 @@ describe('GetSearchResultsHandler tests', () => {
          ];
 
          // act
-         const result = await getSearchResultsHandler(event);
+         const result = await postSearchResultsHandler(event);
 
          // assert
          expect(result.body.results).toEqual(expectedItems);
@@ -235,7 +235,7 @@ describe('GetSearchResultsHandler tests', () => {
          ];
 
          // act
-         const result = await getSearchResultsHandler(event);
+         const result = await postSearchResultsHandler(event);
 
          // assert
          expect(result.body.results).toEqual(expectedItems);
@@ -345,7 +345,7 @@ describe('GetSearchResultsHandler tests', () => {
          ];
 
          // act
-         const result = await getSearchResultsHandler(event);
+         const result = await postSearchResultsHandler(event);
 
          // assert
          expect(result.body.results).toEqual(expectedItems);
@@ -442,7 +442,7 @@ describe('GetSearchResultsHandler tests', () => {
          ];
 
          // act
-         const result = await getSearchResultsHandler(event);
+         const result = await postSearchResultsHandler(event);
 
          // assert
          expect(result.body.results).toEqual(expectedItems);
@@ -540,7 +540,7 @@ describe('GetSearchResultsHandler tests', () => {
          ];
 
          // act
-         const result = await getSearchResultsHandler(event);
+         const result = await postSearchResultsHandler(event);
 
          // assert
          expect(result.body.results).toEqual(expectedItems);

--- a/backend/isoko-backend/src/handlers/business/post-search-results.js
+++ b/backend/isoko-backend/src/handlers/business/post-search-results.js
@@ -37,7 +37,7 @@ const buildQueryParams = (location, category) => {
 /**
  * HTTP get method to get all businesses that match search criteria.
  */
-exports.getSearchResultsHandler = async (event) => {
+exports.postSearchResultsHandler = async (event) => {
    if (event.httpMethod !== 'GET') {
       throw new Error(
          `getSearchResults only accept GET method, you tried: ${event.httpMethod}`

--- a/backend/isoko-backend/template.yml
+++ b/backend/isoko-backend/template.yml
@@ -22,7 +22,7 @@ Resources:
   getSearchResultsFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: src/handlers/business/get-search-results.getSearchResultsHandler
+      Handler: src/handlers/business/post-search-results.postSearchResultsHandler
       Runtime: nodejs14.x
       Architectures:
         - x86_64


### PR DESCRIPTION
Changed search results a GET endpoint so we can take in parameters from request body instead of query params