### PR TITLE
Fix POST /business endpoint

### DIFF
--- a/backend/isoko-backend/__tests__/unit/handlers/business/post-list-business.test.js
+++ b/backend/isoko-backend/__tests__/unit/handlers/business/post-list-business.test.js
@@ -21,7 +21,7 @@ describe('PostListBusinessHandler tests', () => {
       putSpy.mockReset();
    });
 
-   describe('Invalid query param tests', () => {
+   describe('Invalid event tests', () => {
       it('Should throw an error when wrong HTTP method is used', async () => {
          // arrange
          const event = {
@@ -29,21 +29,70 @@ describe('PostListBusinessHandler tests', () => {
          };
 
          // act
+         const response = await postListBusinessHandler(event);
 
          // assert
-         await expect(async () => {
-            await postListBusinessHandler(event);
-         }).rejects.toThrowError();
+         expect(response.statusCode).toBe(400);
+         expect(response.body.error).toContain('GET');
+      });
+
+      it('Should return 400 response when type is ommitted', async () => {
+         // arrange
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify({}),
+         };
+
+         // act
+         const response = await postListBusinessHandler(event);
+
+         // assert
+         expect(response.statusCode).toBe(400);
+         expect(response.body.error).toBe('type is a required field.');
+      });
+
+      it('Should return 400 response when B&M required fields are ommitted', async () => {
+         // arrange
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify({
+               type: 'B&M',
+            }),
+         };
+
+         // act
+         const response = await postListBusinessHandler(event);
+
+         // assert
+         expect(response.statusCode).toBe(400);
+         expect(response.body.error).toBe(
+            'name and street are required fields for Brick and Mortar Businesses.'
+         );
+      });
+
+      it('Should return 400 response when online required fields are ommitted', async () => {
+         // arrange
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify({
+               type: 'Online',
+            }),
+         };
+
+         // act
+         const response = await postListBusinessHandler(event);
+
+         // assert
+         expect(response.statusCode).toBe(400);
+         expect(response.body.error).toBe(
+            'name and links.BusinessURL are required fields for Online businesses.'
+         );
       });
    });
 
    describe('Failed put test', () => {
       it('Should return a 400 response when put throws an error', async () => {
          // arrange
-         expectedItem = {
-            statusCode: 400,
-            body: { error: Error('Put failed') },
-         };
          putSpy.mockImplementation(() => {
             throw new Error('Put failed');
          });
@@ -53,24 +102,27 @@ describe('PostListBusinessHandler tests', () => {
             body: JSON.stringify({
                name: "Bluth's Original Frozen Banana",
                street: '70 Newport Pier',
-               businessId: '-664125567',
+               type: 'B&M',
             }),
          };
 
          // act
-         const result = await postListBusinessHandler(event);
+         const response = await postListBusinessHandler(event);
 
          // assert
-         expect(result).toEqual(expectedItem);
+         expect(response.statusCode).toEqual(400);
+         expect(response.body.error).toEqual('Put failed');
       });
    });
 
    describe('Valid input tests', () => {
       it('Should post business info with all optional params included and return details', async () => {
          // arrange
-         mockPutResults = {
-            pk: '-664125567',
-            sk: 'INFO',
+         putSpy.mockReturnValue({
+            promise: () => Promise.resolve({}),
+         });
+
+         const postBusiness = {
             name: "Bluth's Original Frozen Banana",
             city: 'Newport Beach',
             state: 'CA',
@@ -101,239 +153,25 @@ describe('PostListBusinessHandler tests', () => {
                ownerPhoto:
                   'https://static.wikia.nocookie.net/arresteddevelopment/images/c/c2/Season_1_Character_Promos_-_Maeby_F%C3%BCnke_02.jpeg/revision/latest/scale-to-width-down/300?cb=20120429230807',
             },
-            photos: [],
-            reviews: [],
             lister: 'George Michael Bluth',
-         };
-         putSpy.mockReturnValue({
-            promise: () => Promise.resolve({ Items: mockPutResults }),
-         });
-         const event = {
-            httpMethod: 'POST',
-            body: JSON.stringify({
-               name: "Bluth's Original Frozen Banana",
-               city: 'Newport Beach',
-               state: 'CA',
-               street: '70 Newport Pier',
-               zip: '92663',
-               type: 'B&M',
-               tags: ['Women-Owned'],
-               category: 'Desserts',
-               shortDesc: "There's always money in the banana stand.",
-               businessId: '-664125567',
-               hours: {
-                  Mon: '11:00am - 11:00pm',
-                  Tue: '11:00am - 11:00pm',
-                  Wed: '11:00am - 11:00pm',
-                  Thu: '11:00am - 11:00pm',
-                  Fri: '11:00am - 11:00pm',
-                  Sat: '12:00pm - 8:00pm',
-                  Sun: 'closed',
-               },
-               links: {
-                  Menu: 'https://arresteddevelopment.fandom.com/wiki/Bluth%27s_Original_Frozen_Banana_Stand',
-               },
-               aboutOwner: {
-                  owner: '3bed9528-9d10-4f50-ab72-d19dad1b8698',
-                  ownerName: 'Maeby Funke',
-                  ownerPhone: '123-456-7890',
-                  ownerDesc: 'Marry me!',
-                  ownerPhoto:
-                     'https://static.wikia.nocookie.net/arresteddevelopment/images/c/c2/Season_1_Character_Promos_-_Maeby_F%C3%BCnke_02.jpeg/revision/latest/scale-to-width-down/300?cb=20120429230807',
-               },
-               photos: [],
-               reviews: [],
-               lister: 'George Michael Bluth',
-            }),
          };
 
-         const expectedItems = {
-            name: "Bluth's Original Frozen Banana",
-            city: 'Newport Beach',
-            state: 'CA',
-            street: '70 Newport Pier',
-            zip: '92663',
-            type: 'B&M',
-            tags: ['Women-Owned'],
-            category: 'Desserts',
-            shortDesc: "There's always money in the banana stand.",
-            businessId: '-664125567',
-            hours: {
-               Mon: '11:00am - 11:00pm',
-               Tue: '11:00am - 11:00pm',
-               Wed: '11:00am - 11:00pm',
-               Thu: '11:00am - 11:00pm',
-               Fri: '11:00am - 11:00pm',
-               Sat: '12:00pm - 8:00pm',
-               Sun: 'closed',
-            },
-            links: {
-               Menu: 'https://arresteddevelopment.fandom.com/wiki/Bluth%27s_Original_Frozen_Banana_Stand',
-            },
-            aboutOwner: {
-               owner: '3bed9528-9d10-4f50-ab72-d19dad1b8698',
-               ownerName: 'Maeby Funke',
-               ownerPhone: '123-456-7890',
-               ownerDesc: 'Marry me!',
-               ownerPhoto:
-                  'https://static.wikia.nocookie.net/arresteddevelopment/images/c/c2/Season_1_Character_Promos_-_Maeby_F%C3%BCnke_02.jpeg/revision/latest/scale-to-width-down/300?cb=20120429230807',
-            },
-            photos: [],
-            reviews: [],
-            lister: 'George Michael Bluth',
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify(postBusiness),
          };
 
          // act
          const result = await postListBusinessHandler(event);
 
          // assert
-         expect(result.body.results).toEqual(expectedItems);
+         expect(result.body).toEqual(postBusiness);
          expect(putSpy).toHaveBeenCalledWith({
             TableName: BUSINESS_TABLE,
             Item: {
                pk: '-664125567',
                sk: 'INFO',
-               name: "Bluth's Original Frozen Banana",
-               city: 'Newport Beach',
-               state: 'CA',
-               street: '70 Newport Pier',
-               zip: '92663',
-               type: 'B&M',
-               tags: ['Women-Owned'],
-               category: 'Desserts',
-               shortDesc: "There's always money in the banana stand.",
-               businessId: '-664125567',
-               hours: {
-                  Mon: '11:00am - 11:00pm',
-                  Tue: '11:00am - 11:00pm',
-                  Wed: '11:00am - 11:00pm',
-                  Thu: '11:00am - 11:00pm',
-                  Fri: '11:00am - 11:00pm',
-                  Sat: '12:00pm - 8:00pm',
-                  Sun: 'closed',
-               },
-               links: {
-                  Menu: 'https://arresteddevelopment.fandom.com/wiki/Bluth%27s_Original_Frozen_Banana_Stand',
-               },
-               aboutOwner: {
-                  owner: '3bed9528-9d10-4f50-ab72-d19dad1b8698',
-                  ownerName: 'Maeby Funke',
-                  ownerPhone: '123-456-7890',
-                  ownerDesc: 'Marry me!',
-                  ownerPhoto:
-                     'https://static.wikia.nocookie.net/arresteddevelopment/images/c/c2/Season_1_Character_Promos_-_Maeby_F%C3%BCnke_02.jpeg/revision/latest/scale-to-width-down/300?cb=20120429230807',
-               },
-               photos: [],
-               reviews: [],
-               lister: 'George Michael Bluth',
-            },
-         });
-      });
-
-      it('Should post business info from non-owner "List a Business" page and return details', async () => {
-         // arrange
-         mockPutResults = {
-            pk: '-664125567',
-            sk: 'INFO',
-            name: "Bluth's Original Frozen Banana",
-            city: 'Newport Beach',
-            state: 'CA',
-            street: '70 Newport Pier',
-            zip: '92663',
-            type: 'B&M',
-            tags: ['Women-Owned'],
-            category: 'Desserts',
-            shortDesc: '',
-            businessId: '-664125567',
-            hours: {},
-            links: {},
-            aboutOwner: {
-               ownerName: 'Maeby Funke',
-               ownerPhone: '123-456-7890',
-            },
-            photos: [],
-            reviews: [],
-            lister: 'George Michael Bluth',
-         };
-         putSpy.mockReturnValue({
-            promise: () => Promise.resolve({ Items: mockPutResults }),
-         });
-         const event = {
-            httpMethod: 'POST',
-            body: JSON.stringify({
-               name: "Bluth's Original Frozen Banana",
-               city: 'Newport Beach',
-               state: 'CA',
-               street: '70 Newport Pier',
-               zip: '92663',
-               type: 'B&M',
-               tags: ['Women-Owned'],
-               category: 'Desserts',
-               businessId: '-664125567',
-               aboutOwner: {
-                  ownerName: 'Maeby Funke',
-                  ownerPhone: '123-456-7890',
-               },
-               photos: [],
-               reviews: [],
-               lister: 'George Michael Bluth',
-            }),
-         };
-
-         const expectedItems = {
-            name: "Bluth's Original Frozen Banana",
-            city: 'Newport Beach',
-            state: 'CA',
-            street: '70 Newport Pier',
-            zip: '92663',
-            type: 'B&M',
-            tags: ['Women-Owned'],
-            category: 'Desserts',
-            shortDesc: '',
-            businessId: '-664125567',
-            hours: {},
-            links: {},
-            aboutOwner: {
-               ownerName: 'Maeby Funke',
-               ownerPhone: '123-456-7890',
-            },
-            photos: [],
-            reviews: [],
-            lister: 'George Michael Bluth',
-         };
-
-         // act
-         const result = await postListBusinessHandler(event);
-
-         // assert
-         expect(result.body.results).toEqual(expectedItems);
-         expect(putSpy).toHaveBeenCalledWith({
-            TableName: BUSINESS_TABLE,
-            Item: {
-               pk: '-664125567',
-               sk: 'INFO',
-               name: "Bluth's Original Frozen Banana",
-               city: 'Newport Beach',
-               state: 'CA',
-               street: '70 Newport Pier',
-               zip: '92663',
-               type: 'B&M',
-               tags: ['Women-Owned'],
-               category: 'Desserts',
-               shortDesc: '',
-               businessId: '-664125567',
-               hours: {},
-               links: {},
-               aboutOwner: {
-                  owner: '',
-                  ownerDesc: '',
-                  ownerName: 'Maeby Funke',
-                  ownerPhone: '123-456-7890',
-                  ownerPhoto: '',
-               },
-               photos: [],
-               reviews: [],
-               lister: 'George Michael Bluth',
+               ...postBusiness,
             },
          });
       });

--- a/backend/isoko-backend/package.json
+++ b/backend/isoko-backend/package.json
@@ -19,8 +19,7 @@
       "format-check": "prettier --check \"**/*.+(js|json|ts)\"",
       "lint": "eslint --ext .js,.jsx,.ts,.tsx ./src --quiet",
       "lint-autofix": "eslint --ext .js,.jsx,.ts,.tsx ./src --quiet --fix",
-      "sam-deploy": "sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name isoko-backend --s3-bucket aws-sam-cli-managed-default-samclisourcebucket-1qv27121x2wo3 --capabilities CAPABILITY_IAM --region us-west-2 ",
-      "prepare": "cd ../.. && husky install backend/isoko-backend/.husky"
+      "sam-deploy": "sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name isoko-backend --s3-bucket aws-sam-cli-managed-default-samclisourcebucket-1qv27121x2wo3 --capabilities CAPABILITY_IAM --region us-west-2 "
    },
    "jest": {
       "testPathIgnorePatterns": [

--- a/backend/isoko-backend/src/handlers/business/post-list-business.js
+++ b/backend/isoko-backend/src/handlers/business/post-list-business.js
@@ -89,7 +89,7 @@ exports.postListBusinessHandler = async (event) => {
    let response;
 
    try {
-      console.info(params);
+      console.info(`DynamoDB put params: ${params}`);
       await docClient.put(params).promise();
 
       response = {


### PR DESCRIPTION
Fixed POST /business endpoint. The main issue was with the response from the docClient.post() function, which was expecting the same response as a query() call but instead it actually returns an empty object on success. Tested this end-to-end so once this goes in it should make our listBusiness page work properly