### PR TITLE
[IS-106] Return both ONLINE and B&M results

### DIFF
--- a/backend/isoko-backend/__tests__/unit/handlers/business/post-search-results.test.js
+++ b/backend/isoko-backend/__tests__/unit/handlers/business/post-search-results.test.js
@@ -2,7 +2,7 @@ const {
    postSearchResultsHandler,
 } = require('../../../../src/handlers/business/post-search-results.js');
 const dynamodb = require('aws-sdk/clients/dynamodb');
-const { SEARCH_RESULTS_TABLE } = require('../../../../src/constants');
+const { SEARCH_RESULTS_TABLE, ONLINE } = require('../../../../src/constants');
 
 jest.mock('aws-sdk/clients/dynamodb');
 
@@ -117,8 +117,457 @@ describe('PostSearchResultsHandler tests', () => {
       });
    });
 
-   describe('Valid Input tests', () => {
-      it('Should retrieve all results with matching pk', async () => {
+   describe('Valid Input ONLINE tests', () => {
+      it('Should retrieve all ONLINE results with matching pk', async () => {
+         // arrange
+         mockQueryResults = [
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID1',
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               pk: ONLINE,
+               sk: 'salon#BUSID2',
+               name: "Tyler's Salon",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Haircuts'],
+               stars: 3.8,
+               shortDesc: "Tyler's Salon Description",
+               numReviews: 12,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+         ];
+         querySpy.mockReturnValue({
+            promise: () => Promise.resolve({ Items: mockQueryResults }),
+         });
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify({
+               location: ONLINE,
+            }),
+         };
+
+         const expectedItems = [
+            {
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               name: "Tyler's Salon",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Haircuts'],
+               stars: 3.8,
+               shortDesc: "Tyler's Salon Description",
+               numReviews: 12,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+         ];
+
+         // act
+         const result = await postSearchResultsHandler(event);
+         const resultBody = JSON.parse(result.body);
+
+         // assert
+         expect(resultBody.online).toEqual(expectedItems);
+         expect(querySpy).toHaveBeenCalledWith({
+            TableName: SEARCH_RESULTS_TABLE,
+            KeyConditionExpression: '#pk = :location',
+            ExpressionAttributeNames: {
+               '#pk': 'pk',
+            },
+            ExpressionAttributeValues: {
+               ':location': ONLINE,
+            },
+         });
+      });
+
+      it('Should retrieve all ONLINE results with matching pk and category', async () => {
+         // arrange
+         mockQueryResults = [
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID1',
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+         ];
+         querySpy.mockReturnValue({
+            promise: () => Promise.resolve({ Items: mockQueryResults }),
+         });
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify({
+               category: 'restaurant',
+               location: ONLINE,
+            }),
+         };
+
+         const expectedItems = [
+            {
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+         ];
+
+         // act
+         const result = await postSearchResultsHandler(event);
+         const resultBody = JSON.parse(result.body);
+
+         // assert
+         expect(resultBody.online).toEqual(expectedItems);
+         expect(querySpy).toHaveBeenCalledWith({
+            TableName: SEARCH_RESULTS_TABLE,
+            KeyConditionExpression:
+               '#pk = :location AND begins_with(#sk, :cat)',
+            ExpressionAttributeNames: {
+               '#pk': 'pk',
+               '#sk': 'sk',
+            },
+            ExpressionAttributeValues: {
+               ':location': ONLINE,
+               ':cat': 'restaurant',
+            },
+         });
+      });
+
+      it('Should filter ONLINE results by tag if provided', async () => {
+         // arrange
+         mockQueryResults = [
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID1',
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID1',
+               name: 'Koja Kitchen',
+               type: ONLINE,
+               tags: ['Asian-Owned', 'LGBTQ-Owned'],
+               keywords: ['Korean', 'Bulgolgi'],
+               stars: 4.5,
+               shortDesc: 'Koja Kitchen Description',
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID4',
+               name: 'Santa Cruz Tacqueria',
+               type: ONLINE,
+               tags: ['Latinx-Owned', 'LGBTQ-Owned'],
+               keywords: ['Tacos', 'Chips'],
+               stars: 4.5,
+               shortDesc: 'Santa Cruz Tacqueria Description',
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID4',
+               photo: 'BUSID4#COVERPHOTO',
+            },
+         ];
+         querySpy.mockReturnValue({
+            promise: () => Promise.resolve({ Items: mockQueryResults }),
+         });
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify({
+               category: 'restaurant',
+               tags: ['Asian-Owned', 'Latinx-Owned'],
+               location: ONLINE,
+            }),
+         };
+
+         const expectedItems = [
+            {
+               name: 'Koja Kitchen',
+               type: ONLINE,
+               tags: ['Asian-Owned', 'LGBTQ-Owned'],
+               keywords: ['Korean', 'Bulgolgi'],
+               stars: 4.5,
+               shortDesc: 'Koja Kitchen Description',
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+            {
+               name: 'Santa Cruz Tacqueria',
+               type: ONLINE,
+               tags: ['Latinx-Owned', 'LGBTQ-Owned'],
+               keywords: ['Tacos', 'Chips'],
+               stars: 4.5,
+               shortDesc: 'Santa Cruz Tacqueria Description',
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID4',
+               photo: 'BUSID4#COVERPHOTO',
+            },
+         ];
+
+         // act
+         const result = await postSearchResultsHandler(event);
+         const resultBody = JSON.parse(result.body);
+
+         // assert
+         expect(resultBody.online).toEqual(expectedItems);
+         expect(querySpy).toHaveBeenCalledWith({
+            TableName: SEARCH_RESULTS_TABLE,
+            KeyConditionExpression:
+               '#pk = :location AND begins_with(#sk, :cat)',
+            ExpressionAttributeNames: {
+               '#pk': 'pk',
+               '#sk': 'sk',
+            },
+            ExpressionAttributeValues: {
+               ':location': ONLINE,
+               ':cat': 'restaurant',
+            },
+         });
+      });
+
+      it('Should filter ONLINE results by keyword if provided', async () => {
+         // arrange
+         mockQueryResults = [
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID1',
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID1',
+               name: 'Koja Kitchen',
+               type: ONLINE,
+               tags: ['Asian-Owned', 'LGBTQ-Owned'],
+               keywords: ['Korean', 'Bulgolgi'],
+               stars: 4.5,
+               shortDesc: 'Koja Kitchen Description',
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID4',
+               name: 'Santa Cruz Tacqueria',
+               type: ONLINE,
+               tags: ['Latinx-Owned', 'LGBTQ-Owned'],
+               keywords: ['Tacos', 'Chips'],
+               stars: 4.5,
+               shortDesc: 'Santa Cruz Tacqueria Description',
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID4',
+               photo: 'BUSID4#COVERPHOTO',
+            },
+         ];
+         querySpy.mockReturnValue({
+            promise: () => Promise.resolve({ Items: mockQueryResults }),
+         });
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify({
+               category: 'restaurant',
+               keyword: 'Korean',
+               location: ONLINE,
+            }),
+         };
+
+         const expectedItems = [
+            {
+               name: 'Koja Kitchen',
+               type: ONLINE,
+               tags: ['Asian-Owned', 'LGBTQ-Owned'],
+               keywords: ['Korean', 'Bulgolgi'],
+               stars: 4.5,
+               shortDesc: 'Koja Kitchen Description',
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+         ];
+
+         // act
+         const result = await postSearchResultsHandler(event);
+         const resultBody = JSON.parse(result.body);
+
+         // assert
+         expect(resultBody.online).toEqual(expectedItems);
+         expect(querySpy).toHaveBeenCalledWith({
+            TableName: SEARCH_RESULTS_TABLE,
+            KeyConditionExpression:
+               '#pk = :location AND begins_with(#sk, :cat)',
+            ExpressionAttributeNames: {
+               '#pk': 'pk',
+               '#sk': 'sk',
+            },
+            ExpressionAttributeValues: {
+               ':location': ONLINE,
+               ':cat': 'restaurant',
+            },
+         });
+      });
+
+      it('Should filter ONLINE results by tag and keyword if both provided', async () => {
+         // arrange
+         mockQueryResults = [
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID1',
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID1',
+               name: 'Koja Kitchen',
+               type: ONLINE,
+               tags: ['Asian-Owned', 'LGBTQ-Owned'],
+               keywords: ['Korean', 'Bulgolgi'],
+               stars: 4.5,
+               shortDesc: 'Koja Kitchen Description',
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID4',
+               name: 'Bon Chon',
+               type: ONLINE,
+               tags: ['Latinx-Owned', 'LGBTQ-Owned'],
+               keywords: ['Korean', 'Wings'],
+               stars: 4.5,
+               shortDesc: 'Bon Chon Description',
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID4',
+               photo: 'BUSID4#COVERPHOTO',
+            },
+         ];
+         querySpy.mockReturnValue({
+            promise: () => Promise.resolve({ Items: mockQueryResults }),
+         });
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify({
+               category: 'restaurant',
+               tags: ['Asian-Owned'],
+               keyword: 'Korean',
+               location: ONLINE,
+            }),
+         };
+
+         const expectedItems = [
+            {
+               name: 'Koja Kitchen',
+               type: ONLINE,
+               tags: ['Asian-Owned', 'LGBTQ-Owned'],
+               keywords: ['Korean', 'Bulgolgi'],
+               stars: 4.5,
+               shortDesc: 'Koja Kitchen Description',
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+         ];
+
+         // act
+         const result = await postSearchResultsHandler(event);
+         const resultBody = JSON.parse(result.body);
+
+         // assert
+         expect(resultBody.online).toEqual(expectedItems);
+         expect(querySpy).toHaveBeenCalledWith({
+            TableName: SEARCH_RESULTS_TABLE,
+            KeyConditionExpression:
+               '#pk = :location AND begins_with(#sk, :cat)',
+            ExpressionAttributeNames: {
+               '#pk': 'pk',
+               '#sk': 'sk',
+            },
+            ExpressionAttributeValues: {
+               ':location': ONLINE,
+               ':cat': 'restaurant',
+            },
+         });
+      });
+   });
+
+   describe('Valid Input B&M tests', () => {
+      it('Should retrieve all B&M results with matching pk', async () => {
          // arrange
          mockQueryResults = [
             {
@@ -196,7 +645,7 @@ describe('PostSearchResultsHandler tests', () => {
          const resultBody = JSON.parse(result.body);
 
          // assert
-         expect(resultBody.results).toEqual(expectedItems);
+         expect(resultBody.brickMortar).toEqual(expectedItems);
          expect(querySpy).toHaveBeenCalledWith({
             TableName: SEARCH_RESULTS_TABLE,
             KeyConditionExpression: '#pk = :location',
@@ -209,7 +658,7 @@ describe('PostSearchResultsHandler tests', () => {
          });
       });
 
-      it('Should retrieve all results with matching pk and category', async () => {
+      it('Should retrieve all B&M results with matching pk and category', async () => {
          // arrange
          mockQueryResults = [
             {
@@ -260,7 +709,7 @@ describe('PostSearchResultsHandler tests', () => {
          const resultBody = JSON.parse(result.body);
 
          // assert
-         expect(resultBody.results).toEqual(expectedItems);
+         expect(resultBody.brickMortar).toEqual(expectedItems);
          expect(querySpy).toHaveBeenCalledWith({
             TableName: SEARCH_RESULTS_TABLE,
             KeyConditionExpression:
@@ -276,7 +725,7 @@ describe('PostSearchResultsHandler tests', () => {
          });
       });
 
-      it('Should filter dynamoDB results by tag if provided', async () => {
+      it('Should filter B&M results by tag if provided', async () => {
          // arrange
          mockQueryResults = [
             {
@@ -371,7 +820,7 @@ describe('PostSearchResultsHandler tests', () => {
          const resultBody = JSON.parse(result.body);
 
          // assert
-         expect(resultBody.results).toEqual(expectedItems);
+         expect(resultBody.brickMortar).toEqual(expectedItems);
          expect(querySpy).toHaveBeenCalledWith({
             TableName: SEARCH_RESULTS_TABLE,
             KeyConditionExpression:
@@ -387,7 +836,7 @@ describe('PostSearchResultsHandler tests', () => {
          });
       });
 
-      it('Should filter dynamoDB results by keyword if provided', async () => {
+      it('Should filter B&M results by keyword if provided', async () => {
          // arrange
          mockQueryResults = [
             {
@@ -469,7 +918,7 @@ describe('PostSearchResultsHandler tests', () => {
          const resultBody = JSON.parse(result.body);
 
          // assert
-         expect(resultBody.results).toEqual(expectedItems);
+         expect(resultBody.brickMortar).toEqual(expectedItems);
          expect(querySpy).toHaveBeenCalledWith({
             TableName: SEARCH_RESULTS_TABLE,
             KeyConditionExpression:
@@ -485,7 +934,7 @@ describe('PostSearchResultsHandler tests', () => {
          });
       });
 
-      it('Should filter dynamoDB results by tag and keyword if both provided', async () => {
+      it('Should filter B&M results by tag and keyword if both provided', async () => {
          // arrange
          mockQueryResults = [
             {
@@ -568,7 +1017,7 @@ describe('PostSearchResultsHandler tests', () => {
          const resultBody = JSON.parse(result.body);
 
          // assert
-         expect(resultBody.results).toEqual(expectedItems);
+         expect(resultBody.brickMortar).toEqual(expectedItems);
          expect(querySpy).toHaveBeenCalledWith({
             TableName: SEARCH_RESULTS_TABLE,
             KeyConditionExpression:
@@ -582,6 +1031,267 @@ describe('PostSearchResultsHandler tests', () => {
                ':cat': 'restaurant',
             },
          });
+      });
+   });
+
+   // Now that both ONLINE and B&M functionality has been tested individually
+   // test that both are fetched and put into the response simultaneously
+   describe('Full functionality tests', () => {
+      it('Should only return ONLINE results when location is ONLINE', async () => {
+         // arrange
+         mockQueryResults = [
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID1',
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               pk: ONLINE,
+               sk: 'salon#BUSID2',
+               name: "Tyler's Salon",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Haircuts'],
+               stars: 3.8,
+               shortDesc: "Tyler's Salon Description",
+               numReviews: 12,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+         ];
+         querySpy.mockReturnValueOnce({
+            promise: () => Promise.resolve({ Items: mockQueryResults }),
+         });
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify({
+               location: ONLINE,
+            }),
+         };
+
+         const expectedItems = [
+            {
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               name: "Tyler's Salon",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Haircuts'],
+               stars: 3.8,
+               shortDesc: "Tyler's Salon Description",
+               numReviews: 12,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+         ];
+
+         // act
+         const result = await postSearchResultsHandler(event);
+         const resultBody = JSON.parse(result.body);
+
+         // assert
+         expect(resultBody.online).toEqual(expectedItems);
+         expect(resultBody.brickMortar).toEqual([]);
+         expect(querySpy).toHaveBeenCalledWith({
+            TableName: SEARCH_RESULTS_TABLE,
+            KeyConditionExpression: '#pk = :location',
+            ExpressionAttributeNames: {
+               '#pk': 'pk',
+            },
+            ExpressionAttributeValues: {
+               ':location': ONLINE,
+            },
+         });
+         expect(querySpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('Should only return both ONLINE and B&M results when location is not ONLINE', async () => {
+         // arrange
+         mockOnlineQueryResults = [
+            {
+               pk: ONLINE,
+               sk: 'restaurant#BUSID1',
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               pk: ONLINE,
+               sk: 'salon#BUSID2',
+               name: "Tyler's Salon",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Haircuts'],
+               stars: 3.8,
+               shortDesc: "Tyler's Salon Description",
+               numReviews: 12,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+         ];
+
+         const mockBrickMortarQueryResults = [
+            {
+               pk: 'CA#Sunnyvale',
+               sk: 'restaurant#BUSID1',
+               name: "Bob's Burgers",
+               city: 'Sunnyvale',
+               type: 'B&M',
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               pk: 'CA#Sunnyvale',
+               sk: 'salon#BUSID2',
+               name: "Tyler's Salon",
+               city: 'Sunnyvale',
+               type: 'B&M',
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Haircuts'],
+               stars: 3.8,
+               shortDesc: "Tyler's Salon Description",
+               numReviews: 12,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+         ];
+
+         querySpy.mockReturnValueOnce({
+            promise: () => Promise.resolve({ Items: mockOnlineQueryResults }),
+         });
+
+         querySpy.mockReturnValueOnce({
+            promise: () =>
+               Promise.resolve({ Items: mockBrickMortarQueryResults }),
+         });
+
+         const event = {
+            httpMethod: 'POST',
+            body: JSON.stringify({
+               location: 'CA#Sunnyvale',
+            }),
+         };
+
+         const expectedOnlinneItems = [
+            {
+               name: "Bob's Burgers",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               name: "Tyler's Salon",
+               type: ONLINE,
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Haircuts'],
+               stars: 3.8,
+               shortDesc: "Tyler's Salon Description",
+               numReviews: 12,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+         ];
+
+         const expectedBrickMortarResults = [
+            {
+               name: "Bob's Burgers",
+               city: 'Sunnyvale',
+               type: 'B&M',
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Burgers', 'Salads'],
+               stars: 4.5,
+               shortDesc: "Bob's Burgers Description",
+               numReviews: 30,
+               verified: true,
+               businessId: 'BUSID1',
+               photo: 'BUSID1#COVERPHOTO',
+            },
+            {
+               name: "Tyler's Salon",
+               city: 'Sunnyvale',
+               type: 'B&M',
+               tags: ['Black-Owned', 'LGBTQ-Owned'],
+               keywords: ['Haircuts'],
+               stars: 3.8,
+               shortDesc: "Tyler's Salon Description",
+               numReviews: 12,
+               verified: true,
+               businessId: 'BUSID2',
+               photo: 'BUSID2#COVERPHOTO',
+            },
+         ];
+
+         // act
+         const result = await postSearchResultsHandler(event);
+         const resultBody = JSON.parse(result.body);
+
+         // assert
+         expect(resultBody.online).toEqual(expectedOnlinneItems);
+         expect(resultBody.brickMortar).toEqual(expectedBrickMortarResults);
+         expect(querySpy).toHaveBeenCalledWith({
+            TableName: SEARCH_RESULTS_TABLE,
+            KeyConditionExpression: '#pk = :location',
+            ExpressionAttributeNames: {
+               '#pk': 'pk',
+            },
+            ExpressionAttributeValues: {
+               ':location': ONLINE,
+            },
+         });
+         expect(querySpy).toHaveBeenCalledWith({
+            TableName: SEARCH_RESULTS_TABLE,
+            KeyConditionExpression: '#pk = :location',
+            ExpressionAttributeNames: {
+               '#pk': 'pk',
+            },
+            ExpressionAttributeValues: {
+               ':location': 'CA#Sunnyvale',
+            },
+         });
+         expect(querySpy).toHaveBeenCalledTimes(2);
       });
    });
 });

--- a/backend/isoko-backend/__tests__/unit/handlers/photos/get-photo-url.test.js
+++ b/backend/isoko-backend/__tests__/unit/handlers/photos/get-photo-url.test.js
@@ -1,75 +1,76 @@
 const {
-    getPhotoUrlHandler,
- } = require('../../../../src/handlers/photos/get-photo-url.js');
- const AWS = require('aws-sdk/');
- 
- jest.mock('aws-sdk', () => {
-    let instance = {
-        getSignedUrlPromise: jest.fn()
-    }; 
-    return { S3: jest.fn(() => instance)}
+   getPhotoUrlHandler,
+} = require('../../../../src/handlers/photos/get-photo-url.js');
+const AWS = require('aws-sdk/');
+
+jest.mock('aws-sdk', () => {
+   let instance = {
+      getSignedUrlPromise: jest.fn(),
+   };
+   return { S3: jest.fn(() => instance) };
 });
- 
- describe('GetPhotoUrlHandler tests', () => {
-    let mockS3; 
- 
-    beforeEach(() => {
-        mockS3 = new AWS.S3(); 
-    });
- 
-    describe('Invalid event tests', () => {
-       it('Should throw an error when wrong HTTP method is used', async () => {
-          // arrange
-          const event = {
-             httpMethod: 'POST',
-             pathParameters: {
-                photoId: '9AA67D6D6EBAE28B97F9B9417',
-             },
-          };
- 
-          // act
-          const response = await getPhotoUrlHandler(event);
- 
-          // assert
-          expect(response.statusCode).toBe(400);
-          expect(response.body.error).toContain('POST');
-       });
 
-       it('Should throw an error when path parameter is missing', async () => {
-        // arrange
-        const event = {
-           httpMethod: 'GET'
-        };
+describe('GetPhotoUrlHandler tests', () => {
+   let mockS3;
 
-        // act
-        const response = await getPhotoUrlHandler(event);
+   beforeEach(() => {
+      mockS3 = new AWS.S3();
+   });
 
-        // assert
-        expect(response.statusCode).toBe(400);
-        expect(response.body.error).toEqual(`Missing query parameter 'photoId'. Request URL format: GET/photos/{photoId}`); 
-     });
-    }); 
+   describe('Invalid event tests', () => {
+      it('Should throw an error when wrong HTTP method is used', async () => {
+         // arrange
+         const event = {
+            httpMethod: 'POST',
+            pathParameters: {
+               photoId: '9AA67D6D6EBAE28B97F9B9417',
+            },
+         };
 
-    describe('Valid input tests', () => {
-        it('Should return url for S3 photo associated with given randomId', async () => {
-            
-            mockGetResults = {
-                uploadURL: 'https://image-bucket-isoko.s3.us-west-2.amazonaws.com/9AA67D6D6EBAE28B97F9B9417.png'
-            }; 
+         // act
+         const response = await getPhotoUrlHandler(event);
 
+         // assert
+         expect(response.statusCode).toBe(400);
+         expect(response.body.error).toContain('POST');
+      });
 
-            mockS3.getSignedUrlPromise.mockReturnValueOnce(mockGetResults); 
-        
-            const event = {
-                httpMethod: 'GET', 
-                pathParameters: {
-                    photoId: '9AA67D6D6EBAE28B97F9B9417',
-                 },
-            }
+      it('Should throw an error when path parameter is missing', async () => {
+         // arrange
+         const event = {
+            httpMethod: 'GET',
+         };
 
-            const result = await mockS3.getSignedUrlPromise(event); 
+         // act
+         const response = await getPhotoUrlHandler(event);
 
-            expect(result).toEqual(mockGetResults); 
-        }); 
-    }); 
-}); 
+         // assert
+         expect(response.statusCode).toBe(400);
+         expect(response.body.error).toEqual(
+            `Missing query parameter 'photoId'. Request URL format: GET/photos/{photoId}`
+         );
+      });
+   });
+
+   describe('Valid input tests', () => {
+      it('Should return url for S3 photo associated with given randomId', async () => {
+         mockGetResults = {
+            uploadURL:
+               'https://image-bucket-isoko.s3.us-west-2.amazonaws.com/9AA67D6D6EBAE28B97F9B9417.png',
+         };
+
+         mockS3.getSignedUrlPromise.mockReturnValueOnce(mockGetResults);
+
+         const event = {
+            httpMethod: 'GET',
+            pathParameters: {
+               photoId: '9AA67D6D6EBAE28B97F9B9417',
+            },
+         };
+
+         const result = await mockS3.getSignedUrlPromise(event);
+
+         expect(result).toEqual(mockGetResults);
+      });
+   });
+});

--- a/backend/isoko-backend/src/constants.js
+++ b/backend/isoko-backend/src/constants.js
@@ -1,6 +1,6 @@
 exports.USER_TABLE = 'Users';
 exports.BUSINESS_TABLE = 'Businesses';
-exports.IMAGE_BUCKET = 'image-bucket-isoko'; 
+exports.IMAGE_BUCKET = 'image-bucket-isoko';
 exports.SEARCH_RESULTS_TABLE = 'SearchResults';
 exports.BRICK_AND_MORTAR = 'B&M';
 exports.ONLINE = 'Online';

--- a/backend/isoko-backend/src/handlers/photos/get-photo-url.js
+++ b/backend/isoko-backend/src/handlers/photos/get-photo-url.js
@@ -1,67 +1,67 @@
 const { IMAGE_BUCKET } = require('../../constants');
-const AWS = require('aws-sdk')
-const s3 = new AWS.S3()
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3();
 const _ = require('lodash');
 
-const URL_EXPIRATION_SECONDS = 300
+const URL_EXPIRATION_SECONDS = 300;
 /**
  * HTTP get method to get business page with details and reviews for specific businessId.
  */
 exports.getPhotoUrlHandler = async (event) => {
    if (event.httpMethod !== 'GET') {
-    return {
-        statusCode: 400,
-        body: {
-           error: `getPhotoUrlHandler only accept GET method, you tried: ${event.httpMethod}`,
-        },
-     };
+      return {
+         statusCode: 400,
+         body: {
+            error: `getPhotoUrlHandler only accept GET method, you tried: ${event.httpMethod}`,
+         },
+      };
    }
 
    console.info('received:', event);
 
-   const photoId = _.get(event, ['pathParameters', 'photoId'], null); 
+   const photoId = _.get(event, ['pathParameters', 'photoId'], null);
 
    if (!photoId) {
-    return {
-        statusCode: 400,
-        body: {
-           error: `Missing query parameter 'photoId'. Request URL format: GET/photos/{photoId}`,
-        },
-     };
+      return {
+         statusCode: 400,
+         body: {
+            error: `Missing query parameter 'photoId'. Request URL format: GET/photos/{photoId}`,
+         },
+      };
    }
 
-   // unique identifier will be provided by frontend in request param 
-   const Key = `${photoId}.jpg`
+   // unique identifier will be provided by frontend in request param
+   const Key = `${photoId}.jpg`;
 
    const params = {
-       Bucket: IMAGE_BUCKET,
-       Key, 
-       Expires: URL_EXPIRATION_SECONDS,
-       ContentType: 'image/jpeg', 
-       ACL: 'public-read'
-   }
+      Bucket: IMAGE_BUCKET,
+      Key,
+      Expires: URL_EXPIRATION_SECONDS,
+      ContentType: 'image/jpeg',
+      ACL: 'public-read',
+   };
 
    try {
-    const uploadURL = await s3.getSignedUrlPromise('putObject', params); 
-    response = {
-        statusCode: 200,
-        headers: {
-            "Content-Type" : "json",
-            "Access-Control-Allow-Origin" : "*" 
-        },
-        body: JSON.stringify({ uploadURL: uploadURL, Key }),
-    }; 
+      const uploadURL = await s3.getSignedUrlPromise('putObject', params);
+      response = {
+         statusCode: 200,
+         headers: {
+            'Content-Type': 'json',
+            'Access-Control-Allow-Origin': '*',
+         },
+         body: JSON.stringify({ uploadURL: uploadURL, Key }),
+      };
    } catch (e) {
-    response = {
-        statusCode: 400,
-        body: { error: e.message },
-    }; 
+      response = {
+         statusCode: 400,
+         body: { error: e.message },
+      };
    }
-   
+
    console.info(
-    `response from: ${event.path} statusCode: ${
-       response.statusCode
-    } body: ${JSON.stringify(response.body)}`
-    );
-    return response;
-}
+      `response from: ${event.path} statusCode: ${
+         response.statusCode
+      } body: ${JSON.stringify(response.body)}`
+   );
+   return response;
+};


### PR DESCRIPTION
Updated POST Search Results endpoint to return both ONLINE and B&M results separately. In the next sprint we'll update the frontend to use the new response format and then go back and remove the results field from this response body.