### PR TITLE
Styling Consistencies, fixed auth inputs to be same as elsewhere

### DIFF
--- a/frontend/isoko/src/pages/Authentication/ForgotPassword.tsx
+++ b/frontend/isoko/src/pages/Authentication/ForgotPassword.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Link, useNavigate } from 'react-router-dom';
 import { CognitoUser, CognitoUserPool } from 'amazon-cognito-identity-js';
 import { environment } from '../../environment/environment';
+import { Form } from 'react-bootstrap';
 
 const LeftDiv = styled.div`
    width: 50%;
@@ -66,13 +67,23 @@ const InputContainer = styled.div`
    width: 70%;
 `;
 
-const StyledInput = styled.input`
+const StyledInput = styled(Form.Control)`
    width: 100%;
+   font-size: 1.0625em;
+   padding: 0px 12px 0px 4px;
    border-radius: 10px;
    border: none;
    height: 32px;
    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
    text-indent: 10px;
+
+   &:focus {
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+      border: 1px solid rgb(249, 125, 11);
+   }
+   ::placeholder {
+      color: #aaaaaa;
+   }
 `;
 
 const StyledLabel = styled.label`

--- a/frontend/isoko/src/pages/Authentication/Login.tsx
+++ b/frontend/isoko/src/pages/Authentication/Login.tsx
@@ -9,6 +9,7 @@ import {
    CognitoUserPool,
 } from 'amazon-cognito-identity-js';
 import { environment } from '../../environment/environment';
+import { Form } from 'react-bootstrap';
 
 const LeftDiv = styled.div`
    width: 50%;
@@ -70,13 +71,23 @@ const InputContainer = styled.div`
    width: 70%;
 `;
 
-const StyledInput = styled.input`
+const StyledInput = styled(Form.Control)`
    width: 100%;
+   font-size: 1.0625em;
+   padding: 0px 12px 0px 4px;
    border-radius: 10px;
    border: none;
    height: 32px;
    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
    text-indent: 10px;
+
+   &:focus {
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+      border: 1px solid rgb(249, 125, 11);
+   }
+   ::placeholder {
+      color: #aaaaaa;
+   }
 `;
 
 const StyledLabel = styled.label`

--- a/frontend/isoko/src/pages/Authentication/SignUp.tsx
+++ b/frontend/isoko/src/pages/Authentication/SignUp.tsx
@@ -8,6 +8,7 @@ import {
    CognitoUserAttribute,
 } from 'amazon-cognito-identity-js';
 import { environment } from '../../environment/environment';
+import { Form } from 'react-bootstrap';
 
 const LeftDiv = styled.div`
    width: 50%;
@@ -69,22 +70,42 @@ const InputContainer = styled.div`
    width: 70%;
 `;
 
-const StyledInput = styled.input`
+const StyledInput = styled(Form.Control)`
    width: 100%;
+   font-size: 1.0625em;
+   padding: 0px 12px 0px 4px;
    border-radius: 10px;
    border: none;
    height: 32px;
    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
    text-indent: 10px;
+
+   &:focus {
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+      border: 1px solid rgb(249, 125, 11);
+   }
+   ::placeholder {
+      color: #aaaaaa;
+   }
 `;
 
-const HalfStyledInput = styled.input`
+const HalfStyledInput = styled(Form.Control)`
    width: 100%;
+   font-size: 1.0625em;
+   padding: 0px 12px 0px 4px;
    border-radius: 10px;
    border: none;
    height: 32px;
    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
    text-indent: 10px;
+
+   &:focus {
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+      border: 1px solid rgb(249, 125, 11);
+   }
+   ::placeholder {
+      color: #aaaaaa;
+   }
 `;
 
 const StyledLabel = styled.label`
@@ -108,6 +129,15 @@ const WideButton = styled(StyledButton)`
    height: 32px;
    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
    text-indent: 10px;
+
+   &:focus {
+      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+      border: 1px solid rgb(249, 125, 11);
+      outline: none;
+   }
+   ::placeholder {
+      color: #aaaaaa;
+   }
 `;
 
 const MainContent = styled.div`


### PR DESCRIPTION
Fixed all inputs like these 
<img width="461" alt="Screen Shot 2022-04-19 at 2 38 11 PM" src="https://user-images.githubusercontent.com/15805074/164106160-d501c1d4-307c-43ee-858c-3f6a8a0c5655.png">

To look more like rest of app
<img width="455" alt="Screen Shot 2022-04-19 at 2 38 43 PM" src="https://user-images.githubusercontent.com/15805074/164106227-7ef8255d-8246-4340-a42b-9ef98f8492f3.png">
