### PR TITLE
[IS-142] Fix incorrect update expression for array values

### DIFF
--- a/backend/isoko-backend/__tests__/unit/handlers/business/put-edit-business-page.test.js
+++ b/backend/isoko-backend/__tests__/unit/handlers/business/put-edit-business-page.test.js
@@ -440,7 +440,7 @@ describe('PutEditBusinessPageHandler tests', () => {
                businessId: '-664125567',
             },
             body: JSON.stringify({
-               tags: ["Asian-Owned"],
+               tags: ['Asian-Owned'],
             }),
          };
 
@@ -456,7 +456,7 @@ describe('PutEditBusinessPageHandler tests', () => {
             },
             UpdateExpression: `set tags = :a`,
             ExpressionAttributeValues: {
-               ':a': ["Asian-Owned"],
+               ':a': ['Asian-Owned'],
             },
             ReturnValues: 'ALL_NEW',
          });

--- a/backend/isoko-backend/__tests__/unit/handlers/business/put-edit-business-page.test.js
+++ b/backend/isoko-backend/__tests__/unit/handlers/business/put-edit-business-page.test.js
@@ -428,6 +428,40 @@ describe('PutEditBusinessPageHandler tests', () => {
          });
       });
 
+      it('Generates correct Update expression for Arrays', async () => {
+         // arrange
+         updateSpy.mockReturnValue({
+            promise: () => Promise.resolve({ Attributes: {} }),
+         });
+
+         const event = {
+            httpMethod: 'PUT',
+            pathParameters: {
+               businessId: '-664125567',
+            },
+            body: JSON.stringify({
+               tags: ["Asian-Owned"],
+            }),
+         };
+
+         // act
+         const result = await putEditBusinessPageHandler(event);
+
+         // assert
+         expect(updateSpy).toHaveBeenCalledWith({
+            TableName: BUSINESS_TABLE,
+            Key: {
+               pk: '-664125567',
+               sk: 'INFO',
+            },
+            UpdateExpression: `set tags = :a`,
+            ExpressionAttributeValues: {
+               ':a': ["Asian-Owned"],
+            },
+            ReturnValues: 'ALL_NEW',
+         });
+      });
+
       it('Should update value of multiple simple target fields', async () => {
          // arrange
          mockUpdateResults = {

--- a/backend/isoko-backend/src/handlers/business/put-edit-business-page.js
+++ b/backend/isoko-backend/src/handlers/business/put-edit-business-page.js
@@ -45,7 +45,7 @@ const buildUpdateExpression = (names, requestBody, attrValues) => {
    let count = 97;
    names.forEach((n) => {
       const val = _.get(requestBody, n);
-      if (typeof val == 'object') {
+      if (typeof val == 'object' && !Array.isArray(val)) {
          count += buildComplexObjectExpression(
             n,
             val,
@@ -95,7 +95,6 @@ exports.putEditBusinessPageHandler = async (event) => {
       'reviews',
       'rating',
       'numReviews',
-      'claimed',
    ];
 
    let exprAttrVals = {};

--- a/backend/isoko-backend/src/handlers/business/put-edit-business-page.js
+++ b/backend/isoko-backend/src/handlers/business/put-edit-business-page.js
@@ -95,6 +95,7 @@ exports.putEditBusinessPageHandler = async (event) => {
       'reviews',
       'rating',
       'numReviews',
+      'claimed',
    ];
 
    let exprAttrVals = {};


### PR DESCRIPTION
Updated PUT business endpoint to properly create update expressions for array value fields. Since Arrays are of type object in Javascript we were trying to make a complex update expression when a normal one worked.