### PR TITLE
Update PUT business to use ExpressionAttributeNames

### DIFF
--- a/backend/isoko-backend/__tests__/unit/handlers/business/put-edit-business-page.test.js
+++ b/backend/isoko-backend/__tests__/unit/handlers/business/put-edit-business-page.test.js
@@ -238,9 +238,12 @@ describe('PutEditBusinessPageHandler tests', () => {
                pk: '-664125567',
                sk: 'INFO',
             },
-            UpdateExpression: `set city = :a`,
+            UpdateExpression: `set #city = :a`,
             ExpressionAttributeValues: {
                ':a': 'Venice Beach',
+            },
+            ExpressionAttributeNames: {
+               '#city': 'city'
             },
             ReturnValues: 'ALL_NEW',
          });
@@ -331,6 +334,7 @@ describe('PutEditBusinessPageHandler tests', () => {
             ExpressionAttributeValues: {
                ':a': 'Lindsay Bluth',
             },
+            ExpressionAttributeNames: {},
             ReturnValues: 'ALL_NEW',
          });
       });
@@ -418,11 +422,15 @@ describe('PutEditBusinessPageHandler tests', () => {
                pk: '-664125567',
                sk: 'INFO',
             },
-            UpdateExpression: `set name = :a, aboutOwner.ownerName = :b, shortDesc = :c`,
+            UpdateExpression: `set #name = :a, aboutOwner.ownerName = :b, #shortDesc = :c`,
             ExpressionAttributeValues: {
                ':a': "Lindsay Bluth's Original Frozen Banana",
                ':b': 'Lindsay Bluth',
                ':c': "There's always money in the banana stand.",
+            },
+            ExpressionAttributeNames: {
+               '#name': 'name',
+               '#shortDesc': 'shortDesc',
             },
             ReturnValues: 'ALL_NEW',
          });
@@ -454,9 +462,12 @@ describe('PutEditBusinessPageHandler tests', () => {
                pk: '-664125567',
                sk: 'INFO',
             },
-            UpdateExpression: `set tags = :a`,
+            UpdateExpression: `set #tags = :a`,
             ExpressionAttributeValues: {
                ':a': ['Asian-Owned'],
+            },
+            ExpressionAttributeNames: {
+               '#tags': 'tags',
             },
             ReturnValues: 'ALL_NEW',
          });
@@ -542,10 +553,14 @@ describe('PutEditBusinessPageHandler tests', () => {
                pk: '-664125567',
                sk: 'INFO',
             },
-            UpdateExpression: `set name = :a, type = :b`,
+            UpdateExpression: `set #name = :a, #type = :b`,
             ExpressionAttributeValues: {
                ':a': "Lindsay Bluth's Original Frozen Banana",
                ':b': 'Online',
+            },
+            ExpressionAttributeNames: {
+               '#name': 'name',
+               '#type': 'type',
             },
             ReturnValues: 'ALL_NEW',
          });

--- a/backend/isoko-backend/src/handlers/business/put-edit-business-page.js
+++ b/backend/isoko-backend/src/handlers/business/put-edit-business-page.js
@@ -38,8 +38,9 @@ const buildComplexObjectExpression = (
  * @param {*} names is a list of names representing attribute names to be updated
  * @param {*} requestBody is an object containing attribute names and new values
  * @param {*} attrValues is an object containing mappings that match update expression
+ * @param {*} attrValues is an object containing mappings that match update expression names
  */
-const buildUpdateExpression = (names, requestBody, attrValues) => {
+const buildUpdateExpression = (names, requestBody, attrValues, attrNames) => {
    let exp = `set `;
    let expArr = [];
    let count = 97;
@@ -55,7 +56,8 @@ const buildUpdateExpression = (names, requestBody, attrValues) => {
          );
       } else {
          const mapping = `:${String.fromCharCode(count)}`;
-         expArr.push(`${n} = ${mapping}`);
+         expArr.push(`#${n} = ${mapping}`);
+         attrNames[`#${n}`] = n;
          attrValues[mapping] = val;
          count += 1;
       }
@@ -99,10 +101,12 @@ exports.putEditBusinessPageHandler = async (event) => {
    ];
 
    let exprAttrVals = {};
+   let exprAttrNames = {};
    const updateExpr = buildUpdateExpression(
       fieldNames,
       requestBody,
-      exprAttrVals
+      exprAttrVals,
+      exprAttrNames,
    );
 
    const params = {
@@ -113,6 +117,7 @@ exports.putEditBusinessPageHandler = async (event) => {
       },
       UpdateExpression: updateExpr,
       ExpressionAttributeValues: exprAttrVals,
+      ExpressionAttributeNames: exprAttrNames,
       ReturnValues: 'ALL_NEW',
    };
 


### PR DESCRIPTION
Updated PUT business endpoint to use ExpressionAttributeNames for variable names as some fields we use are reserved keywords in DynamoDB (ie name, type, etc.). Tested end-to-end.