### PR TITLE
[IS-138] Fix add tag modal not searching properly

### DIFF
--- a/frontend/isoko/src/components/Home/SearchBar.tsx
+++ b/frontend/isoko/src/components/Home/SearchBar.tsx
@@ -5,7 +5,7 @@ import KeywordSearchBar from './KeywordSearchBar';
 import MinoritySearchBar from './MinoritySearchBar';
 import LocationSearchBar from './LocationSearchBar';
 import { Row, Col } from 'react-bootstrap';
-import { useAppDispatch } from '../../app/hooks';
+import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import {
    getSearchResultsAsync,
    setSearchFeatures,
@@ -97,9 +97,19 @@ const MiddleDiv = styled.div`
 `;
 
 const SearchBar: React.FC = () => {
-   const [minorityState, setMinorityState] = useState<Array<string>>([]);
-   const [locationState, setLocationState] = useState('');
-   const [keywordState, setKeywordState] = useState('');
+   const searchResultsStore = useAppSelector((store) => store.searchResults);
+
+   const [minorityState, setMinorityState] = useState<Array<string>>(
+      searchResultsStore.minorityTags
+         .filter((tag) => tag.selected)
+         .map((tag) => tag.text)
+   );
+   const [locationState, setLocationState] = useState(
+      searchResultsStore.location
+   );
+   const [keywordState, setKeywordState] = useState(
+      searchResultsStore.searchTerm
+   );
    const [isHome, setIsHome] = useState(true);
 
    useEffect(() => {

--- a/frontend/isoko/src/components/Home/SearchBar.tsx
+++ b/frontend/isoko/src/components/Home/SearchBar.tsx
@@ -122,6 +122,14 @@ const SearchBar: React.FC = () => {
       }
    }, []);
 
+   useEffect(() => {
+      setMinorityState(
+         searchResultsStore.minorityTags
+            .filter((tag) => tag.selected)
+            .map((tag) => tag.text)
+      );
+   }, [searchResultsStore.minorityTags]);
+
    const dispatch = useAppDispatch();
    const navigate = useNavigate();
 

--- a/frontend/isoko/src/components/search/SortResultsDropdown.tsx
+++ b/frontend/isoko/src/components/search/SortResultsDropdown.tsx
@@ -74,6 +74,7 @@ const SortResultsDropdown: React.FC<SortDropdownProps> = (props) => {
             <div
                onClick={(e) => {
                   setSortKey((e.target as HTMLElement).textContent);
+                  props.sortFunction('rating');
                }}
             >
                Highest rated

--- a/frontend/isoko/src/constants/keywordList.ts
+++ b/frontend/isoko/src/constants/keywordList.ts
@@ -42,6 +42,7 @@ const keywordList = [
    'Andalusian',
    'Anesthesiologists',
    'Animal Assisted Therapy',
+   'Anything',
    'Holistic Animal Care',
    'Animal Physical Therapy',
    'Animal Shelters',

--- a/frontend/isoko/src/features/business/SearchResultsAPI.ts
+++ b/frontend/isoko/src/features/business/SearchResultsAPI.ts
@@ -39,6 +39,7 @@ export const getSearchParams = (
       tags: minorityTags.includes('Any Minority Owned') ? [] : minorityTags,
       ...(categoryList.includes(searchTerm)
          ? { category: searchTerm }
-         : { keyword: searchTerm }),
+         : // send '' as keyword if searching by "Anything"
+           { keyword: searchTerm === 'Anything' ? '' : searchTerm }),
    };
 };

--- a/frontend/isoko/src/pages/SearchResults.tsx
+++ b/frontend/isoko/src/pages/SearchResults.tsx
@@ -183,15 +183,17 @@ const SearchResults: React.FC = () => {
 
    // sort businesses by value of sort dropdown
    const sortBusinesses = (key) => {
+      const sorted = [...filteredBusinesses];
+
       if (key === 'reviews') {
-         setFilteredBusinesses([
-            ...filteredBusinesses.sort((a, b) => b.numReviews - a.numReviews),
-         ]);
+         sorted.sort((a, b) => b.numReviews - a.numReviews);
       } else if (key === 'recent') {
-         setFilteredBusinesses([
-            ...filteredBusinesses.sort((a, b) => a.timestamp - b.timestamp),
-         ]);
+         sorted.sort((a, b) => a.timestamp - b.timestamp);
+      } else if (key === 'rating') {
+         sorted.sort((a, b) => b.rating - a.rating);
       }
+
+      setFilteredBusinesses(sorted);
    };
 
    // Called when a user clicks confirm on Add Tag Modal

--- a/frontend/isoko/src/pages/SearchResults.tsx
+++ b/frontend/isoko/src/pages/SearchResults.tsx
@@ -154,32 +154,6 @@ const SearchResults: React.FC = () => {
       return false;
    };
 
-   // when a user clicks on one of the minority tags on the left, it will be remove the tag from the search
-   const removeTag = (business, tag) => {
-      const tags = business.tags;
-      const selectedTags = searchResultsStore.minorityTags.filter(
-         (t) => t.selected == true
-      );
-
-      const index = selectedTags.map((t) => t.text).indexOf(tag);
-      selectedTags.splice(index, 1);
-
-      // if the tag to remove isn't associated with this business, it should still be displayed
-      if (tags.indexOf(tag) === -1) {
-         return true;
-      }
-
-      // if the tag to remove is the only one associated with this business, it should be removed from results
-      if (tags.length === 1) {
-         return false;
-      }
-
-      // if there are more minorities to filter by, check if other tags associated with business fulfill them
-      if (selectedTags.length > 0) {
-         return selectedTags.some((t) => tags.includes(t.text));
-      }
-   };
-
    // filter businesses based on time
    const filterBusinessesByTime = (e, businesses) => {
       const day = dayOfWeek();
@@ -191,11 +165,19 @@ const SearchResults: React.FC = () => {
       }
    };
 
-   // filter business results when customer removes a tag
-   const filterBusinessesRemoveTag = (key, businesses) => {
+   // Research the database when a user removes a tag
+   const removeTag = (key) => {
       dispatch(removeMinorityTag(key));
-      setFilteredBusinesses(
-         businesses.filter((business) => removeTag(business, key))
+      dispatch(
+         getSearchResultsAsync(
+            getSearchParams(
+               searchResultsStore.location,
+               searchResultsStore.minorityTags
+                  .filter((tag) => tag.selected && tag.text !== key)
+                  .map((tag) => tag.text),
+               searchResultsStore.searchTerm
+            )
+         )
       );
    };
 
@@ -245,12 +227,7 @@ const SearchResults: React.FC = () => {
                            tag.selected === true ? (
                               <SelectedTagRow
                                  key={index}
-                                 onClick={() =>
-                                    filterBusinessesRemoveTag(
-                                       tag.text,
-                                       filteredBusinesses
-                                    )
-                                 }
+                                 onClick={() => removeTag(tag.text)}
                               >
                                  <MinorityTag
                                     key={index}


### PR DESCRIPTION
Fixed add tag modal not searching properly. Bug wasn't with the add tags modal but it was with the search bar not properly using the searchResults store. This pr fixes that and also changed our remove tag functionality to now re-search since searching our database isn't that slow atm.