### PR TITLE
top half of analytics page linked to store

### DIFF
--- a/frontend/isoko/src/pages/BusinessDashboard/Analytics.tsx
+++ b/frontend/isoko/src/pages/BusinessDashboard/Analytics.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Stat from '../../components/business_dashboard/Stat';
 import { Container, Row, Col } from 'react-bootstrap';
 import styled from 'styled-components';
 import RatingGraph from '../../components/business_dashboard/RatingGraph';
+import { Review as ReviewType } from '../../types/GlobalTypes';
 
 const StyledDiv = styled.div`
    text-align: left;
@@ -19,72 +20,83 @@ const ChartTitle = styled.div`
    margin-left: 35%;
 `;
 
+interface ReviewProps extends React.HTMLProps<HTMLDivElement> {
+   rating: number;
+   reviews: Array<ReviewType>;
+}
+
 // will be calculated by retrieving ratings from reviews of a business
-const ratings = [
-   {
-      rating: 5,
-      count: 34,
-   },
-   {
-      rating: 4,
-      count: 10,
-   },
-   {
-      rating: 3,
-      count: 2,
-   },
-   {
-      rating: 2,
-      count: 3,
-   },
-   {
-      rating: 1,
-      count: 5,
-   },
-];
 
-// will be retrieved from rating attribute of business
-const avgRating = 4.02;
+const Analytics: React.FC<ReviewProps> = (props) => {
+   const ratingArray = [
+      {
+         rating: 5,
+         count: 0,
+      },
+      {
+         rating: 4,
+         count: 0,
+      },
+      {
+         rating: 3,
+         count: 0,
+      },
+      {
+         rating: 2,
+         count: 0,
+      },
+      {
+         rating: 1,
+         count: 0,
+      },
+   ];
 
-const Analytics: React.FC = () => (
-   <main>
-      <h1>Business Dashboard Analytics</h1>
-      <Container>
-         <Row>
-            <StyledDiv>
-               <h2>General Analytics</h2>
-            </StyledDiv>
-         </Row>
-         <StyledRow>
-            <Col>
-               <Stat stat="Page Views" value={130} />
-            </Col>
-            <Col>
-               <Stat stat="Unique Views" value={94} />
-            </Col>
-            <Col>
-               <Stat stat="Total Reviews" value={17} />
-            </Col>
-            <Col>
-               <Stat stat="Total Ratings" value={54} />
-            </Col>
-            <Col>
-               <Stat stat="Links Clicked" value={43} />
-            </Col>
-         </StyledRow>
-         <Row>
-            <StyledDiv>
-               <h2>Rating Breakdown</h2>
-            </StyledDiv>
-         </Row>
-         <Row>
-            <ChartTitle>Average Rating - {avgRating}</ChartTitle>
-         </Row>
-         <StyledRow>
-            <RatingGraph ratings={ratings} />
-         </StyledRow>
-      </Container>
-   </main>
-);
+   const buildRatingCount = (ratingCount) => {
+      props.reviews.forEach((review) => {
+         const index = ratingCount.findIndex(
+            (obj) => obj.rating == Math.round(review.stars)
+         );
+         ratingCount[index].count = ratingCount[index].count + 1;
+      });
+      return ratingCount;
+   };
+
+   const totalRatings = props.reviews.length;
+
+   return (
+      <main>
+         <h1>Business Dashboard Analytics</h1>
+         <Container>
+            <Row>
+               <StyledDiv>
+                  <h2>General Analytics</h2>
+               </StyledDiv>
+            </Row>
+            <StyledRow>
+               <Col>
+                  <Stat stat="Page Views" value={130} />
+               </Col>
+               <Col>
+                  <Stat stat="Unique Views" value={94} />
+               </Col>
+               <Col>
+                  <Stat stat="Total Ratings" value={totalRatings} />
+               </Col>
+            </StyledRow>
+            <Row>
+               <StyledDiv>
+                  <h2>Rating Breakdown</h2>
+               </StyledDiv>
+            </Row>
+            <Row>
+               <ChartTitle>Average Rating - {props.rating}</ChartTitle>
+            </Row>
+            <StyledRow>
+               <RatingGraph ratings={buildRatingCount(ratingArray)} />
+            </StyledRow>
+         </Container>
+      </main>
+   );
+};
 
 export default Analytics;

--- a/frontend/isoko/src/pages/BusinessDashboard/BusinessDash.tsx
+++ b/frontend/isoko/src/pages/BusinessDashboard/BusinessDash.tsx
@@ -206,7 +206,12 @@ const BusinessDash: React.FC = () => {
                            photos={dashboardStore.business.photos}
                         />
                      ) : null}
-                     {activeComponent === 'Analytics' ? <Analytics /> : null}
+                     {activeComponent === 'Analytics' ? (
+                        <Analytics
+                           rating={dashboardStore.business.rating}
+                           reviews={dashboardStore.business.reviews}
+                        />
+                     ) : null}
                   </Content>
                )}
             </Row>

--- a/frontend/isoko/src/types/GlobalTypes.ts
+++ b/frontend/isoko/src/types/GlobalTypes.ts
@@ -36,13 +36,15 @@ export interface Hours {
 
 export interface Review {
    reviewAuthor: string;
+   city?: string;
+   state?: string;
    authorUserName: string;
    authorProfilePicture: string;
-   rating: number;
+   stars: number;
    reviewTitle?: string;
    description: string;
    pictures: Array<string>;
-   ts: number;
+   ts: string;
 }
 
 export interface Business {


### PR DESCRIPTION
- updated analytics page so it uses the reviews + rating of a business from the store 
- for "my" business, which has 1 4-star review
- average rating is currently null bc we don't update 'rating' in the Businesses or SearchResults table, i'll create another task to fix that in the POST review endpoint

<img width="1228" alt="Screen Shot 2022-05-24 at 2 37 32 PM" src="https://user-images.githubusercontent.com/43476619/170136644-7333d4d5-3c13-4f7b-b367-27d754855cd3.png">
 